### PR TITLE
nalgebra upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ serde-1 = ["serde", "nalgebra/serde-serialize"]
 
 [dependencies]
 rand = "0.5"
-nalgebra = "0.13"
+nalgebra = "0.16.6"
 float-cmp = "0.2"
 itertools = "0.7"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-kiss3d = "0.12"
+kiss3d = "0.16.4"
 obj = "0.8.1"
 serde_json = "1.0"
 criterion = "0.1"

--- a/examples/show_in_emerald.rs
+++ b/examples/show_in_emerald.rs
@@ -60,15 +60,15 @@ fn main() {
         .map(|pos| Point3::new(pos[0], pos[1], pos[2]))
         .collect();
 
-    let mut indices: Vec<Point3<u32>> = Vec::new();
+    let mut indices: Vec<Point3<u16>> = Vec::new();
     let mut triangles: Vec<(Point3<f32>, Point3<f32>, Point3<f32>)> = Vec::new();
     for object in data.objects.iter() {
         for group in object.groups.iter() {
             for poly in group.polys.iter() {
                 indices.push(Point3::new(
-                    poly[0].0 as u32,
-                    poly[1].0 as u32,
-                    poly[2].0 as u32,
+                    poly[0].0 as u16,
+                    poly[1].0 as u16,
+                    poly[2].0 as u16,
                 ));
                 triangles.push((points[poly[0].0], points[poly[1].0], points[poly[2].0]));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,13 +428,13 @@ fn identify_f<C: Container>(
         let gamma_neg = 0.5 * (-dot_wt - (dot_wt_2 - value_4d).sqrt());
 
         let s_4_positive = Sphere::new(
-            Point3::from_coordinates(
+            Point3::from(
                 alpha * unitvector_u + beta * unitvector_v + gamma_pos * unitvector_t,
             ),
             radius,
         )?;
         let s_4_negative = Sphere::new(
-            Point3::from_coordinates(
+            Point3::from(
                 alpha * unitvector_u + beta * unitvector_v + gamma_neg * unitvector_t,
             ),
             radius,

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "serde-1")]
+
 extern crate nalgebra;
 extern crate serde_json;
 extern crate spherical_cow;


### PR DESCRIPTION
due to rust-lang/rust#49799.

I hit a wierd failure with this example:
```rust
error[E0308]: mismatched types
  --> examples/show_in_emerald.rs:81:9
   |
81 |         indices,
   |         ^^^^^^^ expected u16, found u32
   |
   = note: expected type `std::vec::Vec<nalgebra::Point<u16, _>>`
              found type `std::vec::Vec<nalgebra::Point<u32, _>>`
```

I think indices are `GLuint`, which should still be c_uint/u32. Could you take a closer look?